### PR TITLE
Politics notifications should only go to target.

### DIFF
--- a/map/politicstext.properties
+++ b/map/politicstext.properties
@@ -1,25 +1,31 @@
 War.BUTTON=Declare War!
 War.DESCRIPTION=Put the heads of those cowards on our spears!
 War.NOTIFICATION_SUCCESS=We are at war, may those cowards die quickly and honourless!
-War.OTHER_NOTIFICATION_SUCCESS=They have declared War on us, may their blood fill the seas!
+War.TARGET_NOTIFICATION_SUCCESS=They have declared War on us, may their blood fill the seas!
+War.OTHER_NOTIFICATION_SUCCESS=NONE
 
 Neutral.BUTTON=Declare Neutrality
 Neutral.DESCRIPTION=Cancel the alliance.
 Neutral.NOTIFICATION_SUCCESS=We are no longer allied with those honourless cowards.
-Neutral.OTHER_NOTIFICATION_SUCCESS=They cancelled our alliance.
+Neutral.TARGET_NOTIFICATION_SUCCESS=They cancelled our alliance.
+Neutral.OTHER_NOTIFICATION_SUCCESS=NONE
 
 Peace.BUTTON=Suggest a ceasefire
 Peace.DESCRIPTION=Make peace and prepare for better chances to crush our opponent.
 Peace.NOTIFICATION_SUCCESS=We are no longer at war with those honourless cowards.
-Peace.OTHER_NOTIFICATION_SUCCESS=We have made peace, they are afraid of our mighty army.
+Peace.TARGET_NOTIFICATION_SUCCESS=We have made peace, they are afraid of our mighty army.
+Peace.OTHER_NOTIFICATION_SUCCESS=NONE
 Peace.NOTIFICATION_FAILURE=Those honourless weaklings rejected our ceasefire proposal, now they will die from our swords.
-Peace.OTHER_NOTIFICATION_FAILURE=There will be no peace!
+Peace.TARGET_NOTIFICATION_FAILURE=There will be no peace!
+Peace.OTHER_NOTIFICATION_FAILURE=NONE
 Peace.ACCEPT_QUESTION=Do we want to make peace with those bastards?
 
 Allied.BUTTON=Propose Alliance
 Allied.DESCRIPTION=Propose an alliance.
 Allied.NOTIFICATION_SUCCESS=They accept our alliance proposal.
-Allied.OTHER_NOTIFICATION_SUCCESS=We are now allied and may enter each other's territory.
+Allied.TARGET_NOTIFICATION_SUCCESS=We are now allied and may enter each other's territory.
+Allied.OTHER_NOTIFICATION_SUCCESS=NONE
 Allied.NOTIFICATION_FAILURE=They rejected our alliance proposal.
-Allied.OTHER_NOTIFICATION_FAILURE=There will be no alliance!
+Allied.TARGET_NOTIFICATION_FAILURE=There will be no alliance!
+Allied.OTHER_NOTIFICATION_FAILURE=NONE
 Allied.ACCEPT_QUESTION=Do we want to be allied with them?


### PR DESCRIPTION
Politics notifications should only go to target.

Before this change, notifications will go to all players, which is very confusing because the text implied that you're the target.

This change uses the functionality introduced here:
https://github.com/triplea-game/triplea/commit/5e2a3f3da5ced60856f3f092f81a62b79c9b41f6

To instead make these notifications go to the target player only.